### PR TITLE
Allow POST to omit application/json header

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ var app = express();
 var bodyParser = require('body-parser')
 var jsonParser = bodyParser.json()
 
-var jsonParser = bodyParser.json()
+var jsonParser = bodyParser.json({type: "*/*"})
 
 tasks = [
 	{


### PR DESCRIPTION
I found in expressjs/body-parser#76 that bodyParser.json can accept '_/_' and not require the Content-Type header to be present.
